### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@bufbuild/protobuf": "^2.2.0",
+    "@bufbuild/protobuf": "^2.6.3",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0"
   },


### PR DESCRIPTION
I can't build the vercel demo app because 

Module not found: Package path ./codegenv2 is not exported from package /vercel/path0/node_modules/@bufbuild/protobuf (see exports field in /vercel/path0/node_modules/@bufbuild/protobuf/package.json) https://nextjs.org/docs/messages/module-not-found
Import trace for requested module:
./node_modules/@stately-cloud/client/dist/api/auth/service_pb.js ./node_modules/@stately-cloud/client/dist/auth.js
./node_modules/@stately-cloud/client/dist/index.js ./src/lib/actions.ts

However, syncing the dependency with the other packages fixes it.

Here's the dependency list prior to this change

```
vercel-starter-template@0.1.0 /Users/ryan/Work/vercel-starter-template
├── @bufbuild/protobuf@1.10.1
├─┬ @stately-cloud/client@0.33.0
│ ├── @bufbuild/protobuf@2.6.3
│ ├─┬ @connectrpc/connect-node@2.0.3
│ │ └── @bufbuild/protobuf@2.6.3 deduped
│ └─┬ @connectrpc/connect@2.0.3
│   └── @bufbuild/protobuf@2.6.3 deduped
└─┬ @stately-cloud/schema@0.34.3
  └── @bufbuild/protobuf@2.6.3
```